### PR TITLE
handshake: fix last attribute parsing

### DIFF
--- a/lib/GuacdClient.js
+++ b/lib/GuacdClient.js
@@ -93,7 +93,7 @@ class GuacdClient {
 
         this.log('Server sent handshake: ' + serverHandshake);
 
-        serverHandshake = serverHandshake.split(',');
+        serverHandshake = serverHandshake.replace(';', '').split(',');
         let connectionOptions = [];
 
         serverHandshake.forEach((attribute) => {


### PR DESCRIPTION
Hello,

On the handshake parsing last attribute keeps the semicolon

> 4.args,8.hostname,4.port,6.domain,8.username,8.password,5.width,6.height,3.dpi,15.initial-program,11.color-depth,13.disable-audio,15.enable-printing,12.enable-drive,10.drive-path,17.create-drive-path,7.console,13.console-audio,13.server-layout,8.security,11.ignore-cert,12.disable-auth,10.remote-app,14.remote-app-dir,15.remote-app-args,15.static-channels,11.client-name,16.enable-wallpaper,14.enable-theming,21.enable-font-smoothing,23.enable-full-window-drag,26.enable-desktop-composition,22.enable-menu-animations,16.preconnection-id,18.preconnection-blob;

After the split last attribute is 'preconnection-blob;' instead of 'preconnection-blob' fix PR fixes that :)
