### PR TITLE
Pull the default port option from the ws options

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -9,9 +9,7 @@ class Server extends EventEmitter {
     constructor(wsOptions, guacdOptions, clientOptions, callbacks) {
         super();
 
-        this.wsOptions = Object.assign({
-            port: 8080
-        }, wsOptions);
+        this.wsOptions = Object.assign(wsOptions);
 
         this.guacdOptions = Object.assign({
             host: '127.0.0.1',
@@ -67,7 +65,7 @@ class Server extends EventEmitter {
         this.connectionsCount = 0;
         this.activeConnections = {};
 
-        console.log('Starting websocket server on port ' + this.wsOptions.port);
+        console.log('Starting Guacamole lite websocket server');
 
         this.webSocketServer = new Ws.Server(this.wsOptions);
         this.webSocketServer.on('connection', this.newConnection.bind(this));


### PR DESCRIPTION
If you want to bind to a path on an existing http server the port setting overrides this and it will still spinup on the default port. IE {server: http,path:"/guaclite"}