### PR TITLE
Bug fix/destruct http instance

### DIFF
--- a/lib/Server.js
+++ b/lib/Server.js
@@ -143,7 +143,7 @@ class Server extends EventEmitter {
                 activeConnection.close();
             });
         });      
-        server.clonse();
+        server.close();
     }
 
     newConnection(webSocketConnection) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -137,11 +137,7 @@ class Server extends EventEmitter {
             this.clientOptions.log.stdLog('Closing all connections and exiting...');
         }
 
-        this.webSocketServer.close(() => {
-            this.activeConnections.forEach((activeConnection) => {
-                activeConnection.close();
-            });
-        });
+        this.webSocketServer._server.close();
     }
 
     newConnection(webSocketConnection) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -136,14 +136,14 @@ class Server extends EventEmitter {
         if (this.clientOptions.log.level >= this.LOGLEVEL.NORMAL) {
             this.clientOptions.log.stdLog('Closing all connections and exiting...');
         }
-
+      
+        const server = this.webSocketServer._server;
         this.webSocketServer.close(() => {
             this.activeConnections.forEach((activeConnection) => {
                 activeConnection.close();
             });
         });      
-
-        this.webSocketServer._server.close();
+        server.clonse();
     }
 
     newConnection(webSocketConnection) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -137,6 +137,12 @@ class Server extends EventEmitter {
             this.clientOptions.log.stdLog('Closing all connections and exiting...');
         }
 
+        this.webSocketServer.close(() => {
+            this.activeConnections.forEach((activeConnection) => {
+                activeConnection.close();
+            });
+        });      
+
         this.webSocketServer._server.close();
     }
 


### PR DESCRIPTION
Dear sir,
I found that it seems to be failing to release a port when using 'http' package with guacamole-lite as like as written in README.md. I fixed the lib/Server.js, as to be destructing http explicitly. I would be grateful if you would merge this commit.

Thanks for creating a great npm package.