### PR TITLE
adding audio type to support RDP audio with default Guac common

### DIFF
--- a/lib/GuacdClient.js
+++ b/lib/GuacdClient.js
@@ -83,7 +83,7 @@ class GuacdClient {
             this.clientConnection.connectionSettings.connection.height,
             this.clientConnection.connectionSettings.connection.dpi
         ]);
-        this.sendOpCode(['audio']);
+        this.sendOpCode(['audio', 'audio/L16']);
         this.sendOpCode(['video']);
         this.sendOpCode(['image']);
 


### PR DESCRIPTION
Reference fix:
https://github.com/vadimpronin/guacamole-lite/issues/30#issuecomment-657408660
https://github.com/vadimpronin/guacamole-lite/issues/30

This has been tested functional with guacd 1.1.0 and guac common 1.1.0. 