### PR TITLE
Parametrising sendOpCode

### DIFF
--- a/lib/GuacdClient.js
+++ b/lib/GuacdClient.js
@@ -83,8 +83,8 @@ class GuacdClient {
             this.clientConnection.connectionSettings.connection.height,
             this.clientConnection.connectionSettings.connection.dpi
         ]);
-        this.sendOpCode(['audio', 'audio/L16']);
-        this.sendOpCode(['video']);
+        this.sendOpCode(['audio'].concat(this.clientConnection.query.GUAC_AUDIO || []));
+        this.sendOpCode(['video'].concat(this.clientConnection.query.GUAC_VIDEO || []));
         this.sendOpCode(['image']);
 
         let serverHandshake = this.getFirstOpCodeFromBuffer();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "guacamole-lite",
   "description": "Lite version of guacamole server in node.js. RDP/VNC client for HTML5 browsers",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "keywords": [
     "guacamole",
     "rdp",


### PR DESCRIPTION
Instead of adding the opCodes manually and hardcoded we should allow the developer to use the `query` variables to specify the audio and video OpCodes 