### PR TITLE
Support query injection from decrypted token (e.g. GUAC_AUDIO)

### DIFF
--- a/lib/ClientConnection.js
+++ b/lib/ClientConnection.js
@@ -25,6 +25,10 @@ class ClientConnection {
         try {
             this.connectionSettings = this.decryptToken();
 
+	    if (this.connectionSettings.query) {
+               	Object.assign(this.query, this.connectionSettings.query);
+            }
+
             this.connectionType = this.connectionSettings.connection.type;
 
             this.connectionSettings['connection'] = this.mergeConnectionOptions();


### PR DESCRIPTION
This change allows ClientConnection to support format negotiation values (like GUAC_AUDIO) passed via the encrypted token. The query field is present in the decrypted token but was previously ignored unless duplicated manually in the WebSocket URL.

Guacamole’s protocol supports format negotiation (audio, video, image) via the handshake. This mirrors the behavior of the full Apache Guacamole Java client, which sends both settings and query values when establishing a session.

Without this change, users cannot negotiate audio formats like audio/L16 unless they:
Manually inject GUAC_AUDIO into the URL query string, or
Use a workaround that sends a hardcoded audio handshake (as described in [issue #30](https://github.com/vadimpronin/guacamole-lite/issues/30))

This workaround essentially fakes the handshake, and while it can enable audio, it’s brittle, bypasses MIME negotiation, and does not reflect client capabilities.

This PR offers a more secure, flexible, and forward-compatible approach. It integrates cleanly with existing token-based authentication flows and allows dynamic MIME declarations without modifying frontend code or hardcoding client behavior.

This change is fully backward-compatible:
It does not overwrite query parameters from the WebSocket URL
It only merges values from the token’s query field if they exist