### PR TITLE
Add functional tests for websocket query overrides and timezone

### DIFF
--- a/test/GuacdClient.test.js
+++ b/test/GuacdClient.test.js
@@ -123,6 +123,18 @@ describe('GuacdClient Tests', () => {
         });
     });
 
+    test('Timezone instruction is sent when provided', (done) => {
+        guacdClient.connectionSettings.timezone = 'Europe/Berlin';
+        mockGuacdServer.once('connect', (connection) => {
+            connection.on('handshake-instruction', (instruction) => {
+                if (instruction[0] === 'timezone') {
+                    expect(instruction).toEqual(['timezone', 'Europe/Berlin']);
+                    done();
+                }
+            });
+        });
+    });
+
     // test('Inactivity Timeout', (done) => {
     //     mockGuacdServer.on('connect', (connection) => {
     //         connection.disableHeartBeats = true;

--- a/test/WebSocketServer.test.js
+++ b/test/WebSocketServer.test.js
@@ -89,12 +89,28 @@ describe('WebSocket Server Tests', () => {
             // wsClient.send('select');
         });
 
-        mockGuacdServer.on('connect', (connection) => {
+        mockGuacdServer.once('connect', (connection) => {
             connection.on('handshake-instruction', (instruction) => {
                 expect(instruction).toContain('select');
                 wsClient.close();
                 done();
             });
         });
+    });
+
+    test('Query parameters override token settings', (done) => {
+        const token = generateValidToken();
+        let wsClient;
+        mockGuacdServer.once('connect', (connection) => {
+            connection.on('handshake-instruction', (instruction) => {
+                if (instruction[0] === 'size') {
+                    expect(instruction).toEqual(['size', '800', '600', '120']);
+                    wsClient.close();
+                    done();
+                }
+            });
+        });
+
+        wsClient = new WebSocket(`ws://localhost:${wsPort}/?token=${token}&width=800&height=600&dpi=120`);
     });
 });


### PR DESCRIPTION
## Summary
- add test ensuring query parameters override token settings
- add GuacdClient test to verify timezone instruction
- make prior guacd server test listener run once

## Testing
- `npm test`