### PR TITLE
Support for multiple guacd daemons and session tracking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ mp.sh
 
 docs/guacamole-manual
 /guacamole-common-js
+
+.DS_Store

--- a/lib/ClientConnection.js
+++ b/lib/ClientConnection.js
@@ -3,7 +3,7 @@ const EventEmitter = require('events');
 
 const GuacdClient = require('./GuacdClient.js');
 const Crypt = require('./Crypt.js');
-const {LOGLEVEL, Logger} = require('./Logger.js');
+const { LOGLEVEL, Logger } = require('./Logger.js');
 
 class ClientConnection extends EventEmitter {
 
@@ -69,6 +69,8 @@ class ClientConnection extends EventEmitter {
         );
 
         this.guacdClient.on('open', () => {
+            this.logger.log(LOGLEVEL.VERBOSE, `Guacd connection opened for client ID: ${this.connectionId}, Guacamole ID: ${this.guacdClient.guacamoleConnectionId}`);
+            this.guacamoleConnectionId = this.guacdClient.guacamoleConnectionId;
             this.emit('ready', this);
         });
 
@@ -152,7 +154,7 @@ class ClientConnection extends EventEmitter {
         }
 
         this.logger.log(LOGLEVEL.DEBUG, '[ <<< #     ]       Sending to WS: ```' + message + '```');
-        this.webSocket.send(message, {binary: false, mask: false}, (error) => {
+        this.webSocket.send(message, { binary: false, mask: false }, (error) => {
             if (error && ![this.webSocket.CLOSED, this.webSocket.CLOSING].includes(this.webSocket.readyState)) {
                 this.close(error);
             }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -171,14 +171,14 @@ class Server extends EventEmitter {
             processConnectionSettings: (settings, callback) => callback(undefined, settings)
         }, callbacks);
 
-        // Store session registry interface for join lookups
-        this.sessionRegistry = callbacks.sessionRegistry || null;
+        // Session registry - use provided registry or create internal Map
+        this.sessionRegistry = callbacks.sessionRegistry || new Map();
 
         this.connectionsCount = 0;
         this.activeConnections = new Map();
 
         if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
-            this.clientOptions.log.stdLog('Starting guacamole-lite websocket server with dynamic guacd routing and shared session registry');
+            this.clientOptions.log.stdLog('Starting guacamole-lite websocket server with dynamic guacd routing');
         }
 
         this.webSocketServer = new WebSocketServer(this.wsOptions);
@@ -217,11 +217,11 @@ class Server extends EventEmitter {
     /**
      * Extract guacd routing information from connection token
      * @param {Object} query - Query parameters from WebSocket URL
-     * @returns {Promise<Object>} guacd options for this connection
+     * @returns {Promise<Object>} guacd options and connection info for this connection
      */
     async extractGuacdOptions(query) {
         if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
-            this.clientOptions.log.stdLog('[DynamicRouting] extractGuacdOptions called with query: ' + JSON.stringify(query));
+            this.clientOptions.log.stdLog('[DynamicRouting] extractGuacdOptions called');
         }
 
         try {
@@ -230,22 +230,26 @@ class Server extends EventEmitter {
                 if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
                     this.clientOptions.log.stdLog('[DynamicRouting] No token provided, using default guacd');
                 }
-                return this.defaultGuacdOptions;
+                return {
+                    guacdOptions: this.defaultGuacdOptions,
+                    connectionInfo: null,
+                    isJoin: false
+                };
             }
 
             // Decrypt the token to extract connection settings
             const decryptedSettings = this.decryptToken(query.token);
-            if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
-                this.clientOptions.log.stdLog('[DynamicRouting] Decrypted settings: ' + JSON.stringify(decryptedSettings, null, 2));
-            }
-
             const connection = decryptedSettings.connection;
 
             if (!connection) {
                 if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
                     this.clientOptions.log.stdLog('[DynamicRouting] No connection object in decrypted settings');
                 }
-                return this.defaultGuacdOptions;
+                return {
+                    guacdOptions: this.defaultGuacdOptions,
+                    connectionInfo: null,
+                    isJoin: false
+                };
             }
 
             // Handle session join requests - look up which guacd has the session
@@ -253,7 +257,12 @@ class Server extends EventEmitter {
                 if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
                     this.clientOptions.log.stdLog('[DynamicRouting] This is a join request for session: ' + connection.join);
                 }
-                return await this.handleSessionJoin(connection.join);
+                const sessionGuacdOptions = await this.handleSessionJoin(connection.join);
+                return {
+                    guacdOptions: sessionGuacdOptions,
+                    connectionInfo: connection,
+                    isJoin: true
+                };
             }
 
             // Handle new connections with guacd routing
@@ -263,48 +272,46 @@ class Server extends EventEmitter {
                     port: connection.guacdPort || this.defaultGuacdOptions.port
                 };
 
-                if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
-                    this.clientOptions.log.stdLog('[DynamicRouting] Using dynamic guacd routing: ' + JSON.stringify(dynamicGuacdOptions));
-                }
-
                 if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
                     this.clientOptions.log.stdLog(`[DynamicRouting] Routing new connection to guacd: ${dynamicGuacdOptions.host}:${dynamicGuacdOptions.port}`);
                 }
 
-                return dynamicGuacdOptions;
+                return {
+                    guacdOptions: dynamicGuacdOptions,
+                    connectionInfo: connection,
+                    isJoin: false
+                };
             }
 
             if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
                 this.clientOptions.log.stdLog('[DynamicRouting] No guacd routing specified in token, using default');
             }
-            return this.defaultGuacdOptions;
+            return {
+                guacdOptions: this.defaultGuacdOptions,
+                connectionInfo: connection,
+                isJoin: false
+            };
 
         } catch (error) {
-            if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
-                this.clientOptions.log.errorLog('[DynamicRouting] Error in extractGuacdOptions: ' + error.message);
-            }
             if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
                 this.clientOptions.log.errorLog('[DynamicRouting] Error extracting guacd options: ' + error.message);
             }
-            return this.defaultGuacdOptions;
+            return {
+                guacdOptions: this.defaultGuacdOptions,
+                connectionInfo: null,
+                isJoin: false
+            };
         }
     }
 
     /**
-     * Handle session join requests by looking up the session in the shared registry
+     * Handle session join requests by looking up the session in the registry
      * @param {string} sessionUUID - Session UUID to join
      * @returns {Promise<Object>} guacd options for the session host
      */
     async handleSessionJoin(sessionUUID) {
-        if (!this.sessionRegistry) {
-            if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
-                this.clientOptions.log.errorLog('[DynamicRouting] No session registry available for join request');
-            }
-            return this.defaultGuacdOptions;
-        }
-
         try {
-            const session = await this.sessionRegistry.getSession(sessionUUID);
+            const session = this.sessionRegistry.get(sessionUUID);
 
             if (!session) {
                 if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
@@ -362,8 +369,8 @@ class Server extends EventEmitter {
 
         let query = Url.parse(request.url, true).query;
 
-        // Extract guacd options for this specific connection
-        const dynamicGuacdOptions = await this.extractGuacdOptions(query);
+        // Extract guacd options and connection info for this specific connection
+        const { guacdOptions, connectionInfo, isJoin } = await this.extractGuacdOptions(query);
 
         let newConnection = new ClientConnection(
             this.clientOptions,
@@ -374,10 +381,44 @@ class Server extends EventEmitter {
         );
 
         newConnection.on('ready', (clientConnection) => {
+            console.log('New client connection opened, ID:', clientConnection.connectionId, 'Guacamole ID:', clientConnection.guacamoleConnectionId);
+            // Register session when connection is ready and session ID is available
+            if (clientConnection.guacamoleConnectionId && !isJoin && connectionInfo) {
+                try {
+                    this.sessionRegistry.set(clientConnection.guacamoleConnectionId, {
+                        guacdHost: guacdOptions.host,
+                        guacdPort: guacdOptions.port,
+                        connectionInfo: connectionInfo
+                    });
+
+                    if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                        this.clientOptions.log.stdLog(`[SessionRegistry] Registered session ${clientConnection.guacamoleConnectionId} on guacd ${guacdOptions.host}:${guacdOptions.port}`);
+                    }
+                } catch (error) {
+                    if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                        this.clientOptions.log.errorLog(`[SessionRegistry] Failed to register session: ${error.message}`);
+                    }
+                }
+            }
+
             this.emit('open', clientConnection);
         });
 
         newConnection.on('close', (clientConnection, error) => {
+            // Clean up session from registry when connection closes
+            if (clientConnection.guacamoleConnectionId) {
+                try {
+                    this.sessionRegistry.delete(clientConnection.guacamoleConnectionId);
+                    if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                        this.clientOptions.log.stdLog(`[SessionRegistry] Removed session ${clientConnection.guacamoleConnectionId}`);
+                    }
+                } catch (err) {
+                    if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                        this.clientOptions.log.errorLog(`[SessionRegistry] Failed to remove session: ${err.message}`);
+                    }
+                }
+            }
+
             this.activeConnections.delete(clientConnection.connectionId);
             this.emit('close', clientConnection, error);
         });
@@ -387,7 +428,8 @@ class Server extends EventEmitter {
         });
 
         // Use dynamic guacd options instead of fixed options
-        newConnection.connect(dynamicGuacdOptions);
+        newConnection.connect(guacdOptions);
+        newConnection.guacdOptions = guacdOptions;
 
         this.activeConnections.set(this.connectionsCount, newConnection);
     }

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -172,7 +172,8 @@ class Server extends EventEmitter {
         }, callbacks);
 
         // Session registry - use provided registry or create internal Map
-        this.sessionRegistry = callbacks.sessionRegistry || new Map();
+        // BACKWARD COMPATIBILITY FIX: Handle case where callbacks is undefined
+        this.sessionRegistry = (callbacks && callbacks.sessionRegistry) || new Map();
 
         this.connectionsCount = 0;
         this.activeConnections = new Map();
@@ -233,7 +234,8 @@ class Server extends EventEmitter {
                 return {
                     guacdOptions: this.defaultGuacdOptions,
                     connectionInfo: null,
-                    isJoin: false
+                    isJoin: false,
+                    targetSessionId: null
                 };
             }
 
@@ -248,7 +250,8 @@ class Server extends EventEmitter {
                 return {
                     guacdOptions: this.defaultGuacdOptions,
                     connectionInfo: null,
-                    isJoin: false
+                    isJoin: false,
+                    targetSessionId: null
                 };
             }
 
@@ -261,7 +264,8 @@ class Server extends EventEmitter {
                 return {
                     guacdOptions: sessionGuacdOptions,
                     connectionInfo: connection,
-                    isJoin: true
+                    isJoin: true,
+                    targetSessionId: connection.join
                 };
             }
 
@@ -279,7 +283,8 @@ class Server extends EventEmitter {
                 return {
                     guacdOptions: dynamicGuacdOptions,
                     connectionInfo: connection,
-                    isJoin: false
+                    isJoin: false,
+                    targetSessionId: null
                 };
             }
 
@@ -289,7 +294,8 @@ class Server extends EventEmitter {
             return {
                 guacdOptions: this.defaultGuacdOptions,
                 connectionInfo: connection,
-                isJoin: false
+                isJoin: false,
+                targetSessionId: null
             };
 
         } catch (error) {
@@ -299,7 +305,8 @@ class Server extends EventEmitter {
             return {
                 guacdOptions: this.defaultGuacdOptions,
                 connectionInfo: null,
-                isJoin: false
+                isJoin: false,
+                targetSessionId: null
             };
         }
     }
@@ -370,7 +377,7 @@ class Server extends EventEmitter {
         let query = Url.parse(request.url, true).query;
 
         // Extract guacd options and connection info for this specific connection
-        const { guacdOptions, connectionInfo, isJoin } = await this.extractGuacdOptions(query);
+        const { guacdOptions, connectionInfo, isJoin, targetSessionId } = await this.extractGuacdOptions(query);
 
         let newConnection = new ClientConnection(
             this.clientOptions,
@@ -382,21 +389,54 @@ class Server extends EventEmitter {
 
         newConnection.on('ready', (clientConnection) => {
             console.log('New client connection opened, ID:', clientConnection.connectionId, 'Guacamole ID:', clientConnection.guacamoleConnectionId);
-            // Register session when connection is ready and session ID is available
-            if (clientConnection.guacamoleConnectionId && !isJoin && connectionInfo) {
-                try {
-                    this.sessionRegistry.set(clientConnection.guacamoleConnectionId, {
-                        guacdHost: guacdOptions.host,
-                        guacdPort: guacdOptions.port,
-                        connectionInfo: connectionInfo
-                    });
 
-                    if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
-                        this.clientOptions.log.stdLog(`[SessionRegistry] Registered session ${clientConnection.guacamoleConnectionId} on guacd ${guacdOptions.host}:${guacdOptions.port}`);
+            // Register or update session when connection is ready and session ID is available
+            if (clientConnection.guacamoleConnectionId) {
+                try {
+                    if (isJoin && targetSessionId) {
+                        // This is a join - update the session with join information
+                        const existingSession = this.sessionRegistry.get(targetSessionId);
+                        if (existingSession) {
+                            // Add joined connection info to the session
+                            if (!existingSession.joinedConnections) {
+                                existingSession.joinedConnections = [];
+                            }
+
+                            existingSession.joinedConnections.push({
+                                connectionId: clientConnection.connectionId,
+                                guacamoleConnectionId: clientConnection.guacamoleConnectionId,
+                                joinedAt: new Date().toISOString(),
+                                joinSettings: connectionInfo?.settings || {}
+                            });
+
+                            // Update the session in registry
+                            this.sessionRegistry.set(targetSessionId, existingSession);
+
+                            if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                                this.clientOptions.log.stdLog(`[SessionRegistry] Added join connection ${clientConnection.guacamoleConnectionId} to session ${targetSessionId}`);
+                            }
+                        } else {
+                            if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                                this.clientOptions.log.errorLog(`[SessionRegistry] Cannot add join to session ${targetSessionId} - session not found`);
+                            }
+                        }
+                    } else if (!isJoin && connectionInfo) {
+                        // This is a new session - register it
+                        this.sessionRegistry.set(clientConnection.guacamoleConnectionId, {
+                            guacdHost: guacdOptions.host,
+                            guacdPort: guacdOptions.port,
+                            connectionInfo: connectionInfo,
+                            createdAt: new Date().toISOString(),
+                            joinedConnections: []
+                        });
+
+                        if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                            this.clientOptions.log.stdLog(`[SessionRegistry] Registered new session ${clientConnection.guacamoleConnectionId} on guacd ${guacdOptions.host}:${guacdOptions.port}`);
+                        }
                     }
                 } catch (error) {
                     if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
-                        this.clientOptions.log.errorLog(`[SessionRegistry] Failed to register session: ${error.message}`);
+                        this.clientOptions.log.errorLog(`[SessionRegistry] Failed to register/update session: ${error.message}`);
                     }
                 }
             }
@@ -408,9 +448,27 @@ class Server extends EventEmitter {
             // Clean up session from registry when connection closes
             if (clientConnection.guacamoleConnectionId) {
                 try {
-                    this.sessionRegistry.delete(clientConnection.guacamoleConnectionId);
-                    if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
-                        this.clientOptions.log.stdLog(`[SessionRegistry] Removed session ${clientConnection.guacamoleConnectionId}`);
+                    if (isJoin && targetSessionId) {
+                        // Remove this join connection from the session
+                        const existingSession = this.sessionRegistry.get(targetSessionId);
+                        if (existingSession && existingSession.joinedConnections) {
+                            existingSession.joinedConnections = existingSession.joinedConnections.filter(
+                                conn => conn.guacamoleConnectionId !== clientConnection.guacamoleConnectionId
+                            );
+
+                            // Update the session in registry
+                            this.sessionRegistry.set(targetSessionId, existingSession);
+
+                            if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                                this.clientOptions.log.stdLog(`[SessionRegistry] Removed join connection ${clientConnection.guacamoleConnectionId} from session ${targetSessionId}`);
+                            }
+                        }
+                    } else {
+                        // This was the primary session - remove it entirely
+                        this.sessionRegistry.delete(clientConnection.guacamoleConnectionId);
+                        if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                            this.clientOptions.log.stdLog(`[SessionRegistry] Removed primary session ${clientConnection.guacamoleConnectionId}`);
+                        }
                     }
                 } catch (err) {
                     if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {

--- a/lib/Server.js
+++ b/lib/Server.js
@@ -1,9 +1,10 @@
 const EventEmitter = require('events').EventEmitter;
-const {WebSocketServer} = require('ws');
+const { WebSocketServer } = require('ws');
 const DeepExtend = require('deep-extend');
+const crypto = require('crypto');
 
 const ClientConnection = require('./ClientConnection.js');
-const {LOGLEVEL} = require('./Logger.js');
+const { LOGLEVEL } = require('./Logger.js');
 const Url = require("url");
 
 class Server extends EventEmitter {
@@ -19,7 +20,8 @@ class Server extends EventEmitter {
             }, wsOptions);
         }
 
-        this.guacdOptions = Object.assign({
+        // Store default guacd options for backward compatibility
+        this.defaultGuacdOptions = Object.assign({
             host: '127.0.0.1',
             port: 4822
         }, guacdOptions);
@@ -169,11 +171,14 @@ class Server extends EventEmitter {
             processConnectionSettings: (settings, callback) => callback(undefined, settings)
         }, callbacks);
 
+        // Store session registry interface for join lookups
+        this.sessionRegistry = callbacks.sessionRegistry || null;
+
         this.connectionsCount = 0;
         this.activeConnections = new Map();
 
         if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
-            this.clientOptions.log.stdLog('Starting guacamole-lite websocket server');
+            this.clientOptions.log.stdLog('Starting guacamole-lite websocket server with dynamic guacd routing and shared session registry');
         }
 
         this.webSocketServer = new WebSocketServer(this.wsOptions);
@@ -182,10 +187,9 @@ class Server extends EventEmitter {
         // Bind signal handlers and store references for cleanup
         this.sigTermHandler = this.close.bind(this);
         this.sigIntHandler = this.close.bind(this);
-        
+
         process.on('SIGTERM', this.sigTermHandler);
         process.on('SIGINT', this.sigIntHandler);
-
     }
 
     close() {
@@ -210,10 +214,156 @@ class Server extends EventEmitter {
         });
     }
 
-    newConnection(webSocketConnection, request) {
+    /**
+     * Extract guacd routing information from connection token
+     * @param {Object} query - Query parameters from WebSocket URL
+     * @returns {Promise<Object>} guacd options for this connection
+     */
+    async extractGuacdOptions(query) {
+        if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+            this.clientOptions.log.stdLog('[DynamicRouting] extractGuacdOptions called with query: ' + JSON.stringify(query));
+        }
+
+        try {
+            // If no token provided, use default guacd options
+            if (!query.token) {
+                if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                    this.clientOptions.log.stdLog('[DynamicRouting] No token provided, using default guacd');
+                }
+                return this.defaultGuacdOptions;
+            }
+
+            // Decrypt the token to extract connection settings
+            const decryptedSettings = this.decryptToken(query.token);
+            if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                this.clientOptions.log.stdLog('[DynamicRouting] Decrypted settings: ' + JSON.stringify(decryptedSettings, null, 2));
+            }
+
+            const connection = decryptedSettings.connection;
+
+            if (!connection) {
+                if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                    this.clientOptions.log.stdLog('[DynamicRouting] No connection object in decrypted settings');
+                }
+                return this.defaultGuacdOptions;
+            }
+
+            // Handle session join requests - look up which guacd has the session
+            if (connection.join) {
+                if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                    this.clientOptions.log.stdLog('[DynamicRouting] This is a join request for session: ' + connection.join);
+                }
+                return await this.handleSessionJoin(connection.join);
+            }
+
+            // Handle new connections with guacd routing
+            if (connection.guacdHost || connection.guacdPort) {
+                const dynamicGuacdOptions = {
+                    host: connection.guacdHost || this.defaultGuacdOptions.host,
+                    port: connection.guacdPort || this.defaultGuacdOptions.port
+                };
+
+                if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                    this.clientOptions.log.stdLog('[DynamicRouting] Using dynamic guacd routing: ' + JSON.stringify(dynamicGuacdOptions));
+                }
+
+                if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                    this.clientOptions.log.stdLog(`[DynamicRouting] Routing new connection to guacd: ${dynamicGuacdOptions.host}:${dynamicGuacdOptions.port}`);
+                }
+
+                return dynamicGuacdOptions;
+            }
+
+            if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                this.clientOptions.log.stdLog('[DynamicRouting] No guacd routing specified in token, using default');
+            }
+            return this.defaultGuacdOptions;
+
+        } catch (error) {
+            if (this.clientOptions.log.level >= LOGLEVEL.DEBUG) {
+                this.clientOptions.log.errorLog('[DynamicRouting] Error in extractGuacdOptions: ' + error.message);
+            }
+            if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                this.clientOptions.log.errorLog('[DynamicRouting] Error extracting guacd options: ' + error.message);
+            }
+            return this.defaultGuacdOptions;
+        }
+    }
+
+    /**
+     * Handle session join requests by looking up the session in the shared registry
+     * @param {string} sessionUUID - Session UUID to join
+     * @returns {Promise<Object>} guacd options for the session host
+     */
+    async handleSessionJoin(sessionUUID) {
+        if (!this.sessionRegistry) {
+            if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                this.clientOptions.log.errorLog('[DynamicRouting] No session registry available for join request');
+            }
+            return this.defaultGuacdOptions;
+        }
+
+        try {
+            const session = await this.sessionRegistry.getSession(sessionUUID);
+
+            if (!session) {
+                if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                    this.clientOptions.log.errorLog(`[DynamicRouting] Session ${sessionUUID} not found in registry, using default guacd`);
+                }
+                return this.defaultGuacdOptions;
+            }
+
+            const sessionGuacdOptions = {
+                host: session.guacdHost || this.defaultGuacdOptions.host,
+                port: session.guacdPort || this.defaultGuacdOptions.port
+            };
+
+            if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                this.clientOptions.log.stdLog(`[DynamicRouting] Routing join request for session ${sessionUUID} to guacd: ${sessionGuacdOptions.host}:${sessionGuacdOptions.port}`);
+            }
+
+            return sessionGuacdOptions;
+
+        } catch (error) {
+            if (this.clientOptions.log.level >= LOGLEVEL.NORMAL) {
+                this.clientOptions.log.errorLog(`[DynamicRouting] Error looking up session ${sessionUUID}: ${error.message}`);
+            }
+            return this.defaultGuacdOptions;
+        }
+    }
+
+    /**
+     * Decrypt connection token (reusing existing GuacamoleLite logic)
+     */
+    decryptToken(encryptedToken) {
+        if (!this.clientOptions.crypt || !this.clientOptions.crypt.key) {
+            throw new Error('Encryption key not configured');
+        }
+
+        try {
+            const tokenData = JSON.parse(Buffer.from(encryptedToken, 'base64').toString());
+            const decipher = crypto.createDecipheriv(
+                this.clientOptions.crypt.cypher,
+                this.clientOptions.crypt.key,
+                Buffer.from(tokenData.iv, 'base64')
+            );
+
+            let decrypted = decipher.update(Buffer.from(tokenData.value, 'base64'), null, 'utf8');
+            decrypted += decipher.final('utf8');
+
+            return JSON.parse(decrypted);
+        } catch (error) {
+            throw new Error('Failed to decrypt token: ' + error.message);
+        }
+    }
+
+    async newConnection(webSocketConnection, request) {
         this.connectionsCount++;
 
-        let query = Url.parse(request.url, true).query
+        let query = Url.parse(request.url, true).query;
+
+        // Extract guacd options for this specific connection
+        const dynamicGuacdOptions = await this.extractGuacdOptions(query);
 
         let newConnection = new ClientConnection(
             this.clientOptions,
@@ -236,7 +386,8 @@ class Server extends EventEmitter {
             this.emit('error', clientConnection, error);
         });
 
-        newConnection.connect(this.guacdOptions)
+        // Use dynamic guacd options instead of fixed options
+        newConnection.connect(dynamicGuacdOptions);
 
         this.activeConnections.set(this.connectionsCount, newConnection);
     }

--- a/test-guac/Makefile
+++ b/test-guac/Makefile
@@ -1,10 +1,59 @@
-.PHONY: up down
+.PHONY: help up down build clean logs client admin demo
 
-# Spin everything up
-up:
-	docker compose up --build -d
-	@echo "Open your browser at http://127.0.0.1:9090/"
+help: ## Show this help message
+	@echo "Enhanced GuacamoleLite test-guac environment with multi-guacd routing"
+	@echo ""
+	@echo "Available commands:"
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "  %-15s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
 
-# Tear everything down and erase volumes/left-overs
-down:
-	docker compose down -v --remove-orphans
+up: ## Start all services
+	@echo "Starting enhanced GuacamoleLite test environment..."
+	@echo "Features: Multi-guacd routing, session join tracking, admin dashboard"
+	docker-compose up -d
+	@echo ""
+	@echo "Services started:"
+	@echo "  - Client interface:  http://localhost:9090"
+	@echo "  - Admin dashboard:   http://localhost:9092"
+	@echo "  - guacd instances:   guacd-1, guacd-2, guacd-3"
+	@echo ""
+	@echo "Demo steps:"
+	@echo "  1. Open client interface and create connections on different guacd instances"
+	@echo "  2. Copy session IDs and join them from another browser tab"
+	@echo "  3. Watch the admin dashboard for real-time session join tracking"
+
+down: ## Stop all services
+	docker-compose down
+
+build: ## Build all containers
+	docker-compose build
+
+clean: ## Remove all containers and volumes
+	docker-compose down -v --remove-orphans
+	docker system prune -f
+
+logs: ## Show logs from all services
+	docker-compose logs -f
+
+client: ## Open client interface in browser
+	@echo "Opening client interface..."
+	@open http://localhost:9090 2>/dev/null || xdg-open http://localhost:9090 2>/dev/null || echo "Open http://localhost:9090 in your browser"
+
+admin: ## Open admin dashboard in browser
+	@echo "Opening admin dashboard..."
+	@open http://localhost:9092 2>/dev/null || xdg-open http://localhost:9092 2>/dev/null || echo "Open http://localhost:9092 in your browser"
+
+demo: up ## Start services and open demo interfaces
+	@echo "Waiting for services to start..."
+	@sleep 10
+	@make client
+	@sleep 2
+	@make admin
+	@echo ""
+	@echo "Demo environment ready!"
+	@echo ""
+	@echo "Try this demo scenario:"
+	@echo "  1. Create a new connection on guacd-1"
+	@echo "  2. Copy the session ID from the connection header"
+	@echo "  3. Open a new browser tab, choose 'Join Connection', paste the ID"
+	@echo "  4. Watch the admin dashboard show the join tracking in real-time"
+	@echo "  5. Try connecting to different guacd instances and joining across them"

--- a/test-guac/admin-dashboard/Dockerfile
+++ b/test-guac/admin-dashboard/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:18-alpine
+
+WORKDIR /app
+
+# Copy admin dashboard files
+COPY test-guac/admin-dashboard/package.json .
+COPY test-guac/admin-dashboard/server.js .
+COPY test-guac/admin-dashboard/public ./public
+
+# Install dependencies
+RUN npm install
+
+EXPOSE 3000
+
+CMD ["node", "server.js"]

--- a/test-guac/admin-dashboard/package.json
+++ b/test-guac/admin-dashboard/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "guacamole-lite-admin-dashboard",
+  "version": "1.0.0",
+  "description": "Admin dashboard for enhanced GuacamoleLite with session join tracking",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "axios": "^1.6.2"
+  }
+}

--- a/test-guac/admin-dashboard/public/index.html
+++ b/test-guac/admin-dashboard/public/index.html
@@ -1,0 +1,363 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>GuacamoleLite Admin Dashboard - Session Join Tracking</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 20px;
+      background-color: #f5f5f5;
+    }
+
+    .container {
+      max-width: 1200px;
+      margin: 0 auto;
+    }
+
+    h1 {
+      color: #333;
+      text-align: center;
+      margin-bottom: 30px;
+    }
+
+    .stats-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      gap: 20px;
+      margin-bottom: 30px;
+    }
+
+    .stat-card {
+      background: white;
+      padding: 20px;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      text-align: center;
+    }
+
+    .stat-number {
+      font-size: 2em;
+      font-weight: bold;
+      color: #4285f4;
+    }
+
+    .stat-label {
+      color: #666;
+      margin-top: 5px;
+    }
+
+    .sessions-container {
+      background: white;
+      border-radius: 8px;
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+      overflow: hidden;
+    }
+
+    .sessions-header {
+      background: #4285f4;
+      color: white;
+      padding: 20px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+
+    .refresh-btn {
+      background: rgba(255, 255, 255, 0.2);
+      border: 1px solid rgba(255, 255, 255, 0.3);
+      color: white;
+      padding: 8px 16px;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background 0.2s;
+    }
+
+    .refresh-btn:hover {
+      background: rgba(255, 255, 255, 0.3);
+    }
+
+    .sessions-content {
+      padding: 20px;
+    }
+
+    .session-card {
+      border: 1px solid #e0e0e0;
+      border-radius: 6px;
+      margin-bottom: 15px;
+      overflow: hidden;
+    }
+
+    .session-header {
+      background: #f8f9fa;
+      padding: 15px;
+      border-bottom: 1px solid #e0e0e0;
+    }
+
+    .session-id {
+      font-weight: bold;
+      color: #333;
+      font-family: monospace;
+    }
+
+    .session-info {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+      gap: 10px;
+      margin-top: 10px;
+    }
+
+    .info-item {
+      display: flex;
+      flex-direction: column;
+    }
+
+    .info-label {
+      font-size: 0.8em;
+      color: #666;
+      text-transform: uppercase;
+    }
+
+    .info-value {
+      font-weight: 500;
+      color: #333;
+    }
+
+    .joins-section {
+      padding: 15px;
+    }
+
+    .joins-header {
+      font-weight: bold;
+      color: #555;
+      margin-bottom: 10px;
+    }
+
+    .join-item {
+      background: #f8f9fa;
+      border: 1px solid #dee2e6;
+      border-radius: 4px;
+      padding: 10px;
+      margin-bottom: 8px;
+    }
+
+    .join-info {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+      gap: 8px;
+      font-size: 0.9em;
+    }
+
+    .no-sessions {
+      text-align: center;
+      color: #666;
+      padding: 40px;
+      font-style: italic;
+    }
+
+    .error-message {
+      background: #f8d7da;
+      color: #721c24;
+      padding: 15px;
+      border-radius: 4px;
+      margin: 20px 0;
+    }
+
+    .loading {
+      text-align: center;
+      padding: 40px;
+      color: #666;
+    }
+
+    .timestamp {
+      font-size: 0.8em;
+      color: #999;
+      text-align: center;
+      margin-top: 20px;
+    }
+  </style>
+</head>
+
+<body>
+  <div class="container">
+    <h1>GuacamoleLite Enhanced Fork - Session Join Tracking Dashboard</h1>
+
+    <div class="stats-grid">
+      <div class="stat-card">
+        <div class="stat-number" id="total-sessions">-</div>
+        <div class="stat-label">Active Sessions</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number" id="total-joins">-</div>
+        <div class="stat-label">Total Joins</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number" id="guacd-instances">3</div>
+        <div class="stat-label">guacd Instances</div>
+      </div>
+      <div class="stat-card">
+        <div class="stat-number" id="server-status">-</div>
+        <div class="stat-label">Server Status</div>
+      </div>
+    </div>
+
+    <div class="sessions-container">
+      <div class="sessions-header">
+        <h2>Active Sessions with Join Tracking</h2>
+        <button class="refresh-btn" onclick="loadSessions()">Refresh</button>
+      </div>
+      <div class="sessions-content">
+        <div id="loading" class="loading">Loading session data...</div>
+        <div id="error" class="error-message" style="display: none;"></div>
+        <div id="sessions-list"></div>
+        <div id="timestamp" class="timestamp"></div>
+      </div>
+    </div>
+  </div>
+
+  <script>
+    async function loadSessions() {
+      const loadingEl = document.getElementById('loading');
+      const errorEl = document.getElementById('error');
+      const sessionsEl = document.getElementById('sessions-list');
+      const timestampEl = document.getElementById('timestamp');
+
+      loadingEl.style.display = 'block';
+      errorEl.style.display = 'none';
+      sessionsEl.innerHTML = '';
+
+      try {
+        const response = await fetch('/api/sessions');
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
+        const data = await response.json();
+        loadingEl.style.display = 'none';
+
+        // Update stats
+        document.getElementById('total-sessions').textContent = data.totalSessions || 0;
+
+        let totalJoins = 0;
+        Object.values(data.sessions || {}).forEach(session => {
+          totalJoins += (session.joinedConnections || []).length;
+        });
+        document.getElementById('total-joins').textContent = totalJoins;
+
+        // Check server health
+        try {
+          const healthResponse = await fetch('/api/health');
+          const healthData = await healthResponse.json();
+          document.getElementById('server-status').textContent = healthData.status || 'Unknown';
+        } catch {
+          document.getElementById('server-status').textContent = 'Error';
+        }
+
+        if (data.totalSessions === 0) {
+          sessionsEl.innerHTML = '<div class="no-sessions">No active sessions. Start a connection from the client to see session tracking in action.</div>';
+        } else {
+          renderSessions(data.sessions);
+        }
+
+        timestampEl.textContent = `Last updated: ${new Date().toLocaleString()}`;
+
+      } catch (error) {
+        loadingEl.style.display = 'none';
+        errorEl.style.display = 'block';
+        errorEl.textContent = `Failed to load session data: ${error.message}`;
+        console.error('Error loading sessions:', error);
+      }
+    }
+
+    function renderSessions(sessions) {
+      const sessionsEl = document.getElementById('sessions-list');
+
+      Object.entries(sessions).forEach(([sessionId, session]) => {
+        const sessionCard = document.createElement('div');
+        sessionCard.className = 'session-card';
+
+        const joinCount = (session.joinedConnections || []).length;
+        const createdAt = new Date(session.createdAt).toLocaleString();
+
+        sessionCard.innerHTML = `
+                    <div class="session-header">
+                        <div class="session-id">Session ID: ${sessionId}</div>
+                        <div class="session-info">
+                            <div class="info-item">
+                                <span class="info-label">guacd Instance</span>
+                                <span class="info-value">${session.guacdHost}:${session.guacdPort}</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Protocol</span>
+                                <span class="info-value">${(session.connectionInfo?.type || 'Unknown').toUpperCase()}</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Created</span>
+                                <span class="info-value">${createdAt}</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Joined Connections</span>
+                                <span class="info-value">${joinCount}</span>
+                            </div>
+                        </div>
+                    </div>
+                    ${joinCount > 0 ? renderJoins(session.joinedConnections) : ''}
+                `;
+
+        sessionsEl.appendChild(sessionCard);
+      });
+    }
+
+    function renderJoins(joinedConnections) {
+      if (!joinedConnections || joinedConnections.length === 0) {
+        return '';
+      }
+
+      const joinsHtml = joinedConnections.map(join => {
+        const joinedAt = new Date(join.joinedAt).toLocaleString();
+        const readOnly = join.joinSettings?.['read-only'] ? 'Yes' : 'No';
+
+        return `
+                    <div class="join-item">
+                        <div class="join-info">
+                            <div class="info-item">
+                                <span class="info-label">Connection ID</span>
+                                <span class="info-value">${join.connectionId}</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Guacamole ID</span>
+                                <span class="info-value">${join.guacamoleConnectionId}</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Joined At</span>
+                                <span class="info-value">${joinedAt}</span>
+                            </div>
+                            <div class="info-item">
+                                <span class="info-label">Read-Only</span>
+                                <span class="info-value">${readOnly}</span>
+                            </div>
+                        </div>
+                    </div>
+                `;
+      }).join('');
+
+      return `
+                <div class="joins-section">
+                    <div class="joins-header">Joined Connections (${joinedConnections.length})</div>
+                    ${joinsHtml}
+                </div>
+            `;
+    }
+
+    // Load sessions on page load
+    loadSessions();
+
+    // Auto-refresh every 5 seconds
+    setInterval(loadSessions, 5000);
+  </script>
+</body>
+
+</html>

--- a/test-guac/admin-dashboard/server.js
+++ b/test-guac/admin-dashboard/server.js
@@ -1,0 +1,42 @@
+const express = require('express');
+const axios = require('axios');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const GUACAMOLE_LITE_SERVER = process.env.GUACAMOLE_LITE_SERVER || 'http://guacamole-lite-server:3001';
+
+app.use(express.static(path.join(__dirname, 'public')));
+
+// API endpoint to get session data from GuacamoleLite server
+app.get('/api/sessions', async (req, res) => {
+  try {
+    const response = await axios.get(`${GUACAMOLE_LITE_SERVER}/api/sessions`);
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error fetching sessions:', error.message);
+    res.status(500).json({
+      error: 'Failed to fetch session data',
+      message: error.message
+    });
+  }
+});
+
+// Health check endpoint
+app.get('/api/health', async (req, res) => {
+  try {
+    const response = await axios.get(`${GUACAMOLE_LITE_SERVER}/api/health`);
+    res.json(response.data);
+  } catch (error) {
+    console.error('Error checking health:', error.message);
+    res.status(500).json({
+      error: 'Failed to check server health',
+      message: error.message
+    });
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Admin Dashboard running on port ${PORT}`);
+  console.log(`Connecting to GuacamoleLite server at: ${GUACAMOLE_LITE_SERVER}`);
+});

--- a/test-guac/docker-compose.yml
+++ b/test-guac/docker-compose.yml
@@ -1,10 +1,24 @@
 services:
-  guacd:
+  # Multiple guacd instances to demonstrate dynamic routing
+  guacd-1:
     image: guacamole/guacd:1.5.5
-    container_name: guacd
+    container_name: guacd-1
     restart: unless-stopped
     expose: [ "4822" ]
 
+  guacd-2:
+    image: guacamole/guacd:1.5.5
+    container_name: guacd-2
+    restart: unless-stopped
+    expose: [ "4822" ]
+
+  guacd-3:
+    image: guacamole/guacd:1.5.5
+    container_name: guacd-3
+    restart: unless-stopped
+    expose: [ "4822" ]
+
+  # Test desktop for connections
   desktop-linux:
     build: ./desktop-linux
     container_name: desktop-linux
@@ -13,18 +27,34 @@ services:
       - "3389"  # RDP Port
       - "5900"  # VNC Port
 
+  # Enhanced guacamole-lite server using the fork
   guacamole-lite-server:
     build:
       context: ..
       dockerfile: test-guac/guacamole-lite-server/Dockerfile
     container_name: guacamole-lite-server
-    depends_on: [ guacd ]
+    depends_on: [ guacd-1, guacd-2, guacd-3 ]
     environment:
-      GUACD_HOST: guacd
+      # Default guacd for fallback
+      GUACD_HOST: guacd-1
       GUACD_PORT: 4822
       ENCRYPTION_KEY: MySuperSecretKeyForParamsToken12
-    ports: [ "9091:8080" ]
+    ports: 
+      - "9091:8080"
+      - "3001:3001"
 
+  # Admin dashboard to show session registry and join tracking
+  admin-dashboard:
+    build:
+      context: ..
+      dockerfile: test-guac/admin-dashboard/Dockerfile
+    container_name: admin-dashboard
+    depends_on: [ guacamole-lite-server ]
+    environment:
+      GUACAMOLE_LITE_SERVER: http://guacamole-lite-server:3001
+    ports: [ "9092:3000" ]
+
+  # Enhanced client with guacd selection
   guacamole-lite-client:
     build:
       context: ./guacamole-lite-client

--- a/test-guac/guacamole-lite-client/html/css/style.css
+++ b/test-guac/guacamole-lite-client/html/css/style.css
@@ -1,4 +1,5 @@
-html, body {
+html,
+body {
     height: 100%;
     margin: 0;
     font-family: Arial, sans-serif;
@@ -69,11 +70,17 @@ label {
     color: #555;
 }
 
-input, select {
+input,
+select {
     padding: 10px;
     border: 1px solid #ddd;
     border-radius: 4px;
     font-size: 14px;
+}
+
+select {
+    background-color: white;
+    cursor: pointer;
 }
 
 button {
@@ -89,6 +96,41 @@ button {
 
 button:hover {
     background-color: #3367d6;
+}
+
+.help-text {
+    font-size: 12px;
+    color: #666;
+    margin-top: 5px;
+    font-style: italic;
+}
+
+.info-box {
+    background-color: #f0f8ff;
+    border: 1px solid #bee5eb;
+    border-radius: 4px;
+    padding: 15px;
+    margin-top: 15px;
+}
+
+.info-box p {
+    margin: 0 0 10px 0;
+    font-size: 14px;
+    color: #31708f;
+}
+
+.info-box p:last-child {
+    margin-bottom: 0;
+}
+
+.info-box a {
+    color: #0056b3;
+    text-decoration: none;
+    font-weight: bold;
+}
+
+.info-box a:hover {
+    text-decoration: underline;
 }
 
 #display-screen {
@@ -109,12 +151,24 @@ button:hover {
 
 #display-title {
     font-weight: bold;
+    flex-grow: 1;
+}
+
+#display-info {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    margin: 0 15px;
+    font-size: 0.9em;
+}
+
+#display-guacd {
+    color: #aee;
+    margin-bottom: 2px;
 }
 
 #display-uuid {
-    margin-left: 15px;
     cursor: pointer;
-    font-size: 0.9em;
     color: #aee;
 }
 
@@ -174,4 +228,4 @@ button:hover {
     margin-bottom: 0;
     cursor: pointer;
     font-weight: normal;
-} 
+}

--- a/test-guac/guacamole-lite-client/html/index.html
+++ b/test-guac/guacamole-lite-client/html/index.html
@@ -1,6 +1,6 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>guacamole-lite test</title>
+<title>guacamole-lite test - Enhanced Multi-guacd Demo</title>
 
 <link rel="stylesheet" href="css/style.css">
 
@@ -8,7 +8,7 @@
     <!-- Connection Screen -->
     <div id="connection-screen">
         <div id="connection-form">
-            <h2 class="form-header">Guacamole Remote Connection</h2>
+            <h2 class="form-header">Guacamole Remote Connection - Multi-guacd Demo</h2>
 
             <div class="form-row">
                 <label>Connection Type:</label>
@@ -22,6 +22,16 @@
                         <label for="connection-type-join">Join Connection</label>
                     </div>
                 </div>
+            </div>
+
+            <div class="form-row">
+                <label for="guacd-selection">guacd Instance:</label>
+                <select id="guacd-selection">
+                    <option value="guacd-1:4822">guacd-1:4822 (Default)</option>
+                    <option value="guacd-2:4822">guacd-2:4822</option>
+                    <option value="guacd-3:4822">guacd-3:4822</option>
+                </select>
+                <small class="help-text">Select which guacd instance to route this connection through</small>
             </div>
 
             <div class="form-row">
@@ -78,10 +88,23 @@
                         <label for="read-only">Read-only mode</label>
                     </div>
                 </div>
+                <div class="info-box">
+                    <p><strong>Session Join Tracking:</strong> This demo showcases cross-guacd session joining. When you
+                        join a session, the enhanced fork automatically routes your connection to the correct guacd
+                        instance and tracks your join with timestamps and settings.</p>
+                </div>
             </div>
 
             <div class="form-row" style="margin-top: 20px;">
                 <button id="connect-button">Connect</button>
+            </div>
+
+            <div class="info-box">
+                <p><strong>Multi-guacd Demo:</strong> This enhanced test environment demonstrates dynamic guacd routing.
+                    Each new connection can be routed to a different guacd instance, and session joins automatically
+                    find the correct instance.</p>
+                <p><a href="http://localhost:9092" target="_blank">View Admin Dashboard</a> to see session registry and
+                    join tracking in real-time.</p>
             </div>
         </div>
     </div>
@@ -90,7 +113,10 @@
     <div id="display-screen">
         <div id="display-header">
             <div id="display-title">Remote Connection</div>
-            <span id="display-uuid" title="Click to copy Connection ID"></span>
+            <div id="display-info">
+                <span id="display-guacd" title="guacd instance handling this connection"></span>
+                <span id="display-uuid" title="Click to copy Connection ID"></span>
+            </div>
             <button id="close-button">Disconnect</button>
         </div>
         <!-- The remote-desktop surface -->

--- a/test-guac/guacamole-lite-server/Dockerfile
+++ b/test-guac/guacamole-lite-server/Dockerfile
@@ -1,17 +1,19 @@
-FROM node:22-alpine
+FROM node:18-alpine
 
-WORKDIR /opt/guacamole-lite-server
+WORKDIR /app
 
+# Copy the entire project (including the enhanced fork)
+COPY package.json .
+COPY lib ./lib
+COPY index.js .
+
+# Copy the enhanced server startup script
 COPY test-guac/guacamole-lite-server/start.js .
 
-RUN mkdir guacamole-lite
+# Install dependencies
+RUN npm install
 
-COPY . guacamole-lite
+# Expose WebSocket port and admin API port
+EXPOSE 8080 3001
 
-WORKDIR /opt/guacamole-lite-server/guacamole-lite
-RUN npm install --omit=dev
-
-WORKDIR /opt/guacamole-lite-server
-
-EXPOSE 8080
-CMD ["node","start.js"]
+CMD ["node", "start.js"]

--- a/test-guac/guacamole-lite-server/start.js
+++ b/test-guac/guacamole-lite-server/start.js
@@ -1,18 +1,19 @@
-const GuacamoleLite=require('./guacamole-lite/index.js');
+const GuacamoleLite = require('./index.js');
 
 const websocketOptions = {
     port: 8080
 };
 
+// Default guacd options (used as fallback)
 const guacdOptions = {
-    host:process.env.GUACD_HOST,
-    port:+process.env.GUACD_PORT,
+    host: process.env.GUACD_HOST,
+    port: +process.env.GUACD_PORT,
 };
 
 const clientOptions = {
     crypt: {
         cypher: 'AES-256-CBC',
-        key:process.env.ENCRYPTION_KEY,
+        key: process.env.ENCRYPTION_KEY,
     },
     // Add default RDP audio settings for testing
     connectionDefaultSettings: {
@@ -25,4 +26,67 @@ const clientOptions = {
     },
 };
 
-const guacServer = new GuacamoleLite(websocketOptions, guacdOptions, clientOptions);
+// Create session registry for tracking sessions across guacd instances
+const sessionRegistry = new Map();
+
+// Set up callbacks to provide session registry to the enhanced fork
+const callbacks = {
+    processConnectionSettings: (settings, callback) => callback(undefined, settings),
+    sessionRegistry: sessionRegistry
+};
+
+console.log('Starting enhanced GuacamoleLite server with dynamic guacd routing...');
+console.log('Available guacd instances: guacd-1:4822, guacd-2:4822, guacd-3:4822');
+console.log('Default guacd fallback:', `${guacdOptions.host}:${guacdOptions.port}`);
+
+const guacServer = new GuacamoleLite(websocketOptions, guacdOptions, clientOptions, callbacks);
+
+// Add session registry inspection endpoint for admin dashboard
+const http = require('http');
+const url = require('url');
+
+const adminServer = http.createServer((req, res) => {
+    const parsedUrl = url.parse(req.url, true);
+
+    // Set CORS headers
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+
+    if (req.method === 'OPTIONS') {
+        res.writeHead(200);
+        res.end();
+        return;
+    }
+
+    if (parsedUrl.pathname === '/api/sessions') {
+        // Return session registry contents as JSON
+        const sessions = {};
+        for (const [sessionId, sessionData] of sessionRegistry.entries()) {
+            sessions[sessionId] = sessionData;
+        }
+
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+            sessions: sessions,
+            totalSessions: sessionRegistry.size,
+            timestamp: new Date().toISOString()
+        }, null, 2));
+    } else if (parsedUrl.pathname === '/api/health') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({
+            status: 'healthy',
+            activeConnections: guacServer.activeConnections ? guacServer.activeConnections.size : 0,
+            totalSessions: sessionRegistry.size
+        }));
+    } else {
+        res.writeHead(404, { 'Content-Type': 'text/plain' });
+        res.end('Not Found');
+    }
+});
+
+// Start admin API server on port 3001
+adminServer.listen(3001, () => {
+    console.log('Admin API server running on port 3001');
+    console.log('Session registry endpoint: http://localhost:3001/api/sessions');
+});

--- a/test/ServerDynamicRouting.test.js
+++ b/test/ServerDynamicRouting.test.js
@@ -1,0 +1,449 @@
+const Server = require('../lib/Server');
+const { LOGLEVEL } = require('../lib/Logger');
+
+// Mock the WebSocketServer to avoid port conflicts
+jest.mock('ws', () => ({
+  WebSocketServer: jest.fn().mockImplementation(() => ({
+    on: jest.fn(),
+    close: jest.fn()
+  }))
+}));
+
+describe('Server Dynamic Routing and Session Tracking Tests', () => {
+  let server;
+  let mockSessionRegistry;
+  let wsOptions;
+  let guacdOptions;
+  let clientOptions;
+  let callbacks;
+
+  beforeEach(() => {
+    // Clear all mocks
+    jest.clearAllMocks();
+
+    // Create mock session registry
+    mockSessionRegistry = new Map();
+
+    wsOptions = { port: 8080 };
+    guacdOptions = { host: 'localhost', port: 4822 };
+    clientOptions = {
+      log: { level: LOGLEVEL.ERRORS, stdLog: jest.fn(), errorLog: jest.fn() },
+      crypt: { cypher: 'AES-256-CBC', key: 'MySuperSecretKeyForParamsToken12' }
+    };
+    callbacks = {
+      processConnectionSettings: (settings, callback) => callback(undefined, settings),
+      sessionRegistry: mockSessionRegistry
+    };
+  });
+
+  afterEach(() => {
+    if (server) {
+      server.close();
+      server = null;
+    }
+  });
+
+  describe('Constructor with Session Registry', () => {
+    test('should use provided session registry', () => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, callbacks);
+      expect(server.sessionRegistry).toBe(mockSessionRegistry);
+    });
+
+    test('should create internal Map when no registry provided', () => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, {});
+      expect(server.sessionRegistry).toBeInstanceOf(Map);
+    });
+
+    test('should handle undefined callbacks gracefully', () => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, undefined);
+      expect(server.sessionRegistry).toBeInstanceOf(Map);
+      expect(server.callbacks).toHaveProperty('processConnectionSettings');
+    });
+
+    test('should maintain backward compatibility with original constructor', () => {
+      // This is how the original tests call the constructor
+      server = new Server(wsOptions, guacdOptions, clientOptions);
+      expect(server.sessionRegistry).toBeInstanceOf(Map);
+    });
+  });
+
+  describe('extractGuacdOptions', () => {
+    beforeEach(() => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, callbacks);
+    });
+
+    test('should return default options when no token provided', async () => {
+      const query = {};
+      const result = await server.extractGuacdOptions(query);
+
+      expect(result).toEqual({
+        guacdOptions: { host: 'localhost', port: 4822 },
+        connectionInfo: null,
+        isJoin: false,
+        targetSessionId: null
+      });
+    });
+
+    test('should extract dynamic guacd routing from token', async () => {
+      const tokenData = {
+        connection: {
+          type: 'vnc',
+          guacdHost: 'remote-guacd.example.com',
+          guacdPort: 4823,
+          settings: { hostname: 'vm.example.com', port: '5900' }
+        }
+      };
+
+      // Mock the decryptToken method
+      server.decryptToken = jest.fn().mockReturnValue(tokenData);
+
+      const query = { token: 'encrypted-token' };
+      const result = await server.extractGuacdOptions(query);
+
+      expect(result.guacdOptions).toEqual({
+        host: 'remote-guacd.example.com',
+        port: 4823
+      });
+      expect(result.connectionInfo).toBe(tokenData.connection);
+      expect(result.isJoin).toBe(false);
+      expect(result.targetSessionId).toBeNull();
+    });
+
+    test('should handle session join requests', async () => {
+      const sessionUUID = 'test-session-uuid';
+      const tokenData = {
+        connection: {
+          join: sessionUUID,
+          settings: { 'read-only': true }
+        }
+      };
+
+      // Mock session in registry
+      mockSessionRegistry.set(sessionUUID, {
+        guacdHost: 'session-guacd.example.com',
+        guacdPort: 4824,
+        connectionInfo: { type: 'vnc' }
+      });
+
+      server.decryptToken = jest.fn().mockReturnValue(tokenData);
+
+      const query = { token: 'join-token' };
+      const result = await server.extractGuacdOptions(query);
+
+      expect(result.guacdOptions).toEqual({
+        host: 'session-guacd.example.com',
+        port: 4824
+      });
+      expect(result.isJoin).toBe(true);
+      expect(result.targetSessionId).toBe(sessionUUID);
+    });
+
+    test('should fall back to default when session not found for join', async () => {
+      const tokenData = {
+        connection: {
+          join: 'non-existent-session',
+          settings: { 'read-only': true }
+        }
+      };
+
+      server.decryptToken = jest.fn().mockReturnValue(tokenData);
+
+      const query = { token: 'join-token' };
+      const result = await server.extractGuacdOptions(query);
+
+      expect(result.guacdOptions).toEqual({
+        host: 'localhost',
+        port: 4822
+      });
+      expect(result.isJoin).toBe(true);
+      expect(result.targetSessionId).toBe('non-existent-session');
+    });
+
+    test('should handle partial guacd options in token', async () => {
+      const tokenData = {
+        connection: {
+          type: 'vnc',
+          guacdHost: 'custom-host.example.com',
+          // No guacdPort specified
+          settings: { hostname: 'vm.example.com' }
+        }
+      };
+
+      server.decryptToken = jest.fn().mockReturnValue(tokenData);
+
+      const query = { token: 'partial-token' };
+      const result = await server.extractGuacdOptions(query);
+
+      expect(result.guacdOptions).toEqual({
+        host: 'custom-host.example.com',
+        port: 4822  // Default port
+      });
+    });
+
+    test('should handle decryption errors gracefully', async () => {
+      server.decryptToken = jest.fn().mockImplementation(() => {
+        throw new Error('Decryption failed');
+      });
+
+      const query = { token: 'invalid-token' };
+      const result = await server.extractGuacdOptions(query);
+
+      expect(result.guacdOptions).toEqual({
+        host: 'localhost',
+        port: 4822
+      });
+      expect(result.connectionInfo).toBeNull();
+      expect(result.isJoin).toBe(false);
+      expect(result.targetSessionId).toBeNull();
+    });
+  });
+
+  describe('handleSessionJoin', () => {
+    beforeEach(() => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, callbacks);
+    });
+
+    test('should return session guacd options when session exists', async () => {
+      const sessionUUID = 'existing-session';
+      const sessionData = {
+        guacdHost: 'session-host.example.com',
+        guacdPort: 4825,
+        connectionInfo: { type: 'vnc' }
+      };
+
+      mockSessionRegistry.set(sessionUUID, sessionData);
+
+      const result = await server.handleSessionJoin(sessionUUID);
+
+      expect(result).toEqual({
+        host: 'session-host.example.com',
+        port: 4825
+      });
+    });
+
+    test('should return default options when session does not exist', async () => {
+      const result = await server.handleSessionJoin('non-existent-session');
+
+      expect(result).toEqual({
+        host: 'localhost',
+        port: 4822
+      });
+    });
+
+    test('should handle missing guacdHost in session data', async () => {
+      const sessionUUID = 'partial-session';
+      const sessionData = {
+        guacdPort: 4826,
+        connectionInfo: { type: 'vnc' }
+      };
+
+      mockSessionRegistry.set(sessionUUID, sessionData);
+
+      const result = await server.handleSessionJoin(sessionUUID);
+
+      expect(result).toEqual({
+        host: 'localhost',  // Default host
+        port: 4826
+      });
+    });
+
+    test('should handle registry access errors', async () => {
+      // Mock registry that throws on get
+      const errorRegistry = {
+        get: jest.fn().mockImplementation(() => {
+          throw new Error('Registry error');
+        })
+      };
+
+      server.sessionRegistry = errorRegistry;
+
+      const result = await server.handleSessionJoin('test-session');
+
+      expect(result).toEqual({
+        host: 'localhost',
+        port: 4822
+      });
+    });
+  });
+
+  describe('Session Registration and Join Tracking', () => {
+    beforeEach(() => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, callbacks);
+    });
+
+    test('should register new session with join tracking structure', () => {
+      const connectionInfo = {
+        type: 'vnc',
+        settings: { hostname: 'test-vm.example.com' }
+      };
+      const guacdOptions = { host: 'test-guacd.example.com', port: 4822 };
+
+      // Simulate session registration
+      server.sessionRegistry.set('test-session-id', {
+        guacdHost: guacdOptions.host,
+        guacdPort: guacdOptions.port,
+        connectionInfo: connectionInfo,
+        createdAt: new Date().toISOString(),
+        joinedConnections: []
+      });
+
+      const session = server.sessionRegistry.get('test-session-id');
+      expect(session).toHaveProperty('guacdHost', 'test-guacd.example.com');
+      expect(session).toHaveProperty('guacdPort', 4822);
+      expect(session).toHaveProperty('connectionInfo');
+      expect(session).toHaveProperty('createdAt');
+      expect(session).toHaveProperty('joinedConnections');
+      expect(session.joinedConnections).toEqual([]);
+    });
+
+    test('should add join connection to existing session', () => {
+      const sessionId = 'primary-session';
+
+      // Create primary session
+      server.sessionRegistry.set(sessionId, {
+        guacdHost: 'localhost',
+        guacdPort: 4822,
+        connectionInfo: { type: 'vnc' },
+        createdAt: '2025-09-09T10:00:00.000Z',
+        joinedConnections: []
+      });
+
+      // Add join connection
+      const existingSession = server.sessionRegistry.get(sessionId);
+      existingSession.joinedConnections.push({
+        connectionId: 456,
+        guacamoleConnectionId: 'join-guac-id',
+        joinedAt: new Date().toISOString(),
+        joinSettings: { 'read-only': true }
+      });
+      server.sessionRegistry.set(sessionId, existingSession);
+
+      const session = server.sessionRegistry.get(sessionId);
+      expect(session.joinedConnections).toHaveLength(1);
+      expect(session.joinedConnections[0]).toHaveProperty('connectionId', 456);
+      expect(session.joinedConnections[0]).toHaveProperty('joinSettings');
+      expect(session.joinedConnections[0].joinSettings['read-only']).toBe(true);
+    });
+
+    test('should remove specific join connection without affecting primary session', () => {
+      const sessionId = 'session-with-joins';
+
+      // Create session with multiple joins
+      server.sessionRegistry.set(sessionId, {
+        guacdHost: 'localhost',
+        guacdPort: 4822,
+        connectionInfo: { type: 'vnc' },
+        createdAt: '2025-09-09T10:00:00.000Z',
+        joinedConnections: [
+          {
+            connectionId: 101,
+            guacamoleConnectionId: 'join-1',
+            joinedAt: '2025-09-09T10:01:00.000Z',
+            joinSettings: {}
+          },
+          {
+            connectionId: 102,
+            guacamoleConnectionId: 'join-2',
+            joinedAt: '2025-09-09T10:02:00.000Z',
+            joinSettings: { 'read-only': true }
+          }
+        ]
+      });
+
+      // Remove specific join connection
+      const session = server.sessionRegistry.get(sessionId);
+      session.joinedConnections = session.joinedConnections.filter(
+        conn => conn.guacamoleConnectionId !== 'join-1'
+      );
+      server.sessionRegistry.set(sessionId, session);
+
+      const updatedSession = server.sessionRegistry.get(sessionId);
+      expect(updatedSession.joinedConnections).toHaveLength(1);
+      expect(updatedSession.joinedConnections[0].guacamoleConnectionId).toBe('join-2');
+      expect(updatedSession).toHaveProperty('connectionInfo'); // Primary session preserved
+    });
+
+    test('should handle join to non-existent session gracefully', () => {
+      const nonExistentSession = server.sessionRegistry.get('non-existent');
+      expect(nonExistentSession).toBeUndefined();
+
+      // Attempting to add join to non-existent session should not crash
+      expect(() => {
+        const session = server.sessionRegistry.get('non-existent');
+        if (session) {
+          session.joinedConnections = session.joinedConnections || [];
+          session.joinedConnections.push({});
+        }
+      }).not.toThrow();
+    });
+  });
+
+  describe('Token Decryption', () => {
+    test('should handle missing encryption key', () => {
+      const serverWithoutKey = new Server(
+        wsOptions,
+        guacdOptions,
+        { log: { level: LOGLEVEL.ERRORS, stdLog: jest.fn(), errorLog: jest.fn() }, crypt: {} },
+        callbacks
+      );
+
+      expect(() => {
+        serverWithoutKey.decryptToken('any-token');
+      }).toThrow('Encryption key not configured');
+    });
+
+    test('should handle malformed token data', () => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, callbacks);
+
+      expect(() => {
+        server.decryptToken('not-valid-base64');
+      }).toThrow();
+    });
+  });
+
+  describe('Backward Compatibility', () => {
+    test('should work with original GuacamoleLite constructor patterns', () => {
+      // Test pattern 1: No callbacks
+      let testServer = new Server(wsOptions, guacdOptions, clientOptions);
+      expect(testServer.sessionRegistry).toBeInstanceOf(Map);
+      testServer.close();
+
+      // Test pattern 2: Empty callbacks
+      testServer = new Server(wsOptions, guacdOptions, clientOptions, {});
+      expect(testServer.sessionRegistry).toBeInstanceOf(Map);
+      testServer.close();
+
+      // Test pattern 3: Callbacks with processConnectionSettings only
+      testServer = new Server(wsOptions, guacdOptions, clientOptions, {
+        processConnectionSettings: (settings, cb) => cb(undefined, settings)
+      });
+      expect(testServer.sessionRegistry).toBeInstanceOf(Map);
+      testServer.close();
+    });
+
+    test('should preserve all original properties and methods', () => {
+      server = new Server(wsOptions, guacdOptions, clientOptions, callbacks);
+
+      // Check that all expected properties exist
+      expect(server).toHaveProperty('wsOptions');
+      expect(server).toHaveProperty('defaultGuacdOptions');
+      expect(server).toHaveProperty('clientOptions');
+      expect(server).toHaveProperty('callbacks');
+      expect(server).toHaveProperty('connectionsCount');
+      expect(server).toHaveProperty('activeConnections');
+      expect(server).toHaveProperty('webSocketServer');
+
+      // Check that all expected methods exist
+      expect(server.close).toBeInstanceOf(Function);
+      expect(server.newConnection).toBeInstanceOf(Function);
+
+      // New methods should also exist
+      expect(server.extractGuacdOptions).toBeInstanceOf(Function);
+      expect(server.handleSessionJoin).toBeInstanceOf(Function);
+      expect(server.decryptToken).toBeInstanceOf(Function);
+
+      // New property should exist
+      expect(server).toHaveProperty('sessionRegistry');
+    });
+  });
+});


### PR DESCRIPTION
# Enhanced GuacamoleLite: Dynamic guacd Routing and Session Join Tracking

## Overview

This is an awesome project, thank you for all the work. However, my architecture is distributed involving 100s of guacd daemons. The current code base imposes a 1:1 relationship between guacamole-lite and a guacd daemon which is not scalable in my architecture. I want to have a m:n relationship between guacamole-lite and guacd daemons. This PR enhances GuacamoleLite to support dynamic routing to multiple guacd instances and comprehensive session join tracking. 

## Key Features

### Dynamic Multi-Host Routing
- **Per-connection guacd routing**: Connections can specify `guacdHost` and `guacdPort` in encrypted tokens
- **Session join routing**: Join requests automatically route to the correct guacd instance via session registry lookup
- **Backward compatibility**: Existing configurations continue to work without changes

### Comprehensive Session Join Tracking
- **Session registry integration**: Accepts optional session registry via callbacks (Map interface)
- **Complete join audit trail**: Tracks all joined connections with timestamps, settings, and user identification
- **Smart cleanup**: Individual join disconnections don't affect primary sessions

### Production Architecture Support
- **Horizontal scaling**: Supports 3-5 GuacamoleLite instances serving 100s of guacd instances
- **Cross-instance session sharing**: Sessions created on one GuacamoleLite instance can be joined from another
- **Infrastructure compatibility**: Single WebSocket port design works with firewalls and load balancers

## Technical Implementation

### Modified Files
- `lib/Server.js`: Enhanced with dynamic routing and session tracking
- `lib/ClientConnection.js`: Added session ready event emission

### New Capabilities
1. **extractGuacdOptions()**: Decrypts tokens and determines per-connection guacd routing
2. **handleSessionJoin()**: Routes join requests to correct guacd instance via registry lookup
3. **Session registration**: Automatic session tracking in `'ready'` event with guacd routing metadata
4. **Enhanced session data structure**: Includes `joinedConnections` array with complete join tracking

### Token Structure
```javascript
// New connection with guacd routing
{
  connection: {
    type: 'vnc',
    guacdHost: 'guacd-server-2.internal',
    guacdPort: 4822,
    settings: { hostname: 'vm.example.com', port: '5900' }
  }
}

// Session join with tracking
{
  connection: {
    join: 'session-uuid',
    settings: { 'read-only': true }
  }
}
```

## Backward Compatibility

- **Constructor patterns**: All existing constructor patterns work unchanged
- **Default behavior**: Without guacd routing in tokens, uses default guacd options
- **Session registry**: Creates internal Map when no registry provided
- **All tests pass**: Existing GuacamoleLite test suite passes without modification

## Production Benefits

- **Eliminates single guacd bottleneck**: Enables true horizontal scaling
- **Cross-instance collaboration**: Users can join sessions across multiple GuacamoleLite instances
- **Complete audit trail**: Full visibility into session collaboration with timestamps
- **Infrastructure ready**: Compatible with modern cloud deployment patterns

## Test Coverage

### Unit Tests (`test/ServerDynamicRouting.test.js`)
- **Constructor with Session Registry**: Tests session registry integration and backward compatibility
- **extractGuacdOptions()**: Tests token decryption, dynamic routing, session joins, and error handling
- **handleSessionJoin()**: Tests session lookup, fallback behavior, and registry errors
- **Session Registration and Join Tracking**: Tests session data structure and join management
- **Token Decryption**: Tests encryption key validation and malformed token handling
- **Backward Compatibility**: Tests all original constructor patterns and property preservation

### Integration Tests (Enhanced `test-guac/`)
- **Multi-guacd routing**: Demonstrates routing to guacd-1, guacd-2, guacd-3
- **Session join tracking**: Real-time admin dashboard showing complete join audit trail
- **Cross-instance joins**: VNC connections allowing multiple concurrent sessions
- **Client interface**: guacd selection dropdown and routing visualization

### Compatibility Validation
- **All existing tests pass**: No regressions in original GuacamoleLite test suite
- **Backward compatibility verified**: Original constructor patterns work unchanged
- **Default behavior preserved**: Without routing tokens, uses original fallback logic

## Demo Environment

The enhanced `test-guac/` environment showcases the new capabilities:
- Multiple guacd instances (guacd-1, guacd-2, guacd-3)
- Client interface with guacd selection
- Admin dashboard showing session join tracking
- Cross-instance session joining demonstration

## Breaking Changes

None. This enhancement maintains full backward compatibility while adding new capabilities.